### PR TITLE
Updated docker_pull fixing check of image

### DIFF
--- a/cloud/docker/docker_pull
+++ b/cloud/docker/docker_pull
@@ -131,13 +131,25 @@ class DockerManager:
 
     def check_current_image(self):
         repo, image, tag = self.get_image_parts()
-        for image in self.client.images():
-            if self.image in image['RepoTags']:
-                self.current_image_id = image['Id']
+        
+        image = "{image}:{tag}".format(image=image, tag=tag)
+        image_id = None
+        
+        for _image in self.client.images():
+            if image in _image['RepoTags']:
+                image_id = _image['Id']
+
+        self.current_image_id = image_id
 
     def get_image_parts(self):
         try:
-            return REPO_REGEX.match(self.image).group('repo', 'image', 'tag')
+            repo, image, tag = REPO_REGEX.match(self.image).group('repo',
+                                                                  'image',
+                                                                  'tag')
+            if not tag:
+                tag = 'latest'
+                
+            return (repo, image, tag)
         except Exception as e:
             self.module.fail_json(msg=e.message, image=self.image)
 


### PR DESCRIPTION
check_current_image was failing to find images as they are stored in a list with "<image>:<tag>" and if image: passed from task did not have a tag assuming latest would only contain "<image>"

As part of this I have modified get_image_parts to set tag to latest if not set prior to call.

Ex.
docker_pull:
  image: busybox

Result:
failed: [master01.global.jaacs-local.ohthree.com] => (item=busybox) => {"failed": true, "item": "busybox", "parsed": false}
/home/core/pypy/bin/pypy: /lib64/libssl.so.1.0.0: no version information available (required by /home/core/pypy/bin/pypy)
/home/core/pypy/bin/pypy: /lib64/libcrypto.so.1.0.0: no version information available (required by /home/core/pypy/bin/pypy)
Traceback (most recent call last):
  File "app_main.py", line 75, in run_toplevel
  File "/home/core/.ansible/tmp/ansible-tmp-1424809165.1-76056237946285/docker_pull", line 1829, in <module>
    main()
  File "/home/core/.ansible/tmp/ansible-tmp-1424809165.1-76056237946285/docker_pull", line 259, in main
    manager.run()
  File "/home/core/.ansible/tmp/ansible-tmp-1424809165.1-76056237946285/docker_pull", line 222, in run
    error, msg, changed, output = self.parse_result(result)
  File "/home/core/.ansible/tmp/ansible-tmp-1424809165.1-76056237946285/docker_pull", line 169, in parse_result
    if new_image_id != self.current_image_id:
AttributeError: DockerManager instance has no attribute 'current_image_id'

The cause of this error was current_image_id was not being set, which if defaulted to None would solve the issue, but this would result in no images ever being found if a tag was not provided as part of the image from the task.
